### PR TITLE
Add MacOS Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 /.vscode
 /.idea
 Cargo.lock
+swift_bridge
+libswift_colors.a

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,10 +3,17 @@ name = "egui_system_theme"
 version = "0.1.1"
 edition = "2021"
 
+[features]
+# links swift code
+dynamic-mac-colors = ["dep:swift-bridge", "dep:swift-bridge-build"]
+
+[target."cfg(target_os = \"macos\")".build-dependencies]
+swift-bridge-build = { version = "0.1" , optional = true }
+
 [dependencies]
 dark-light = "1.1.1"
 egui = "0.29"
-once_cell = "1.19.0"
+once_cell = "1.20.2"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 configparser = "3.0.4"
@@ -20,6 +27,7 @@ sysinfo = "0.32"
 [target."cfg(target_os = \"macos\")".dependencies]
 cocoa = "0.26"
 objc = "0.2"
+swift-bridge = { version = "0.1" , optional = true }
 
 [dev-dependencies]
 eframe = "0.29"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "egui_system_theme"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 
 [dependencies]
 dark-light = "1.1.1"
-egui = "0.28"
+egui = "0.29"
 once_cell = "1.19.0"
 
 [target.'cfg(target_os = "linux")'.dependencies]
@@ -15,9 +15,12 @@ palette = "0.7.6"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 windows = { version = "0.58.0", features = ["Win32_Graphics_Gdi"]}
-sysinfo = "0.30.12"
+sysinfo = "0.32"
 
+[target."cfg(target_os = \"macos\")".dependencies]
+cocoa = "0.26"
+objc = "0.2"
 
 [dev-dependencies]
-eframe = "0.28"
-egui_demo_lib = "0.28"
+eframe = "0.29"
+egui_demo_lib = "0.29"

--- a/build.rs
+++ b/build.rs
@@ -5,23 +5,24 @@ fn main() {
 
 #[cfg(all(feature = "dynamic-mac-colors", target_os = "macos"))]
 fn main() {
-    use std::process::Command;
     use std::io::Write;
+    use std::process::Command;
 
     let _ = std::fs::create_dir("./swift_bridge");
     let bridging_header = std::fs::File::create("./swift_bridge/bridging-header.h");
 
     let _ = match bridging_header {
         Ok(mut f) => f.write_all(
-        r#"
-        #ifndef BRIDGING_HEADER_H
-        #define BRIDGING_HEADER_H
+            r#"
+            #ifndef BRIDGING_HEADER_H
+            #define BRIDGING_HEADER_H
 
-        #import "./SwiftBridgeCore.h"
-        #import "./egui_system_theme/egui_system_theme.h"
+            #import "./SwiftBridgeCore.h"
+            #import "./egui_system_theme/egui_system_theme.h"
 
-        #endif BRIDGING_HEADER_H
-        "#.as_bytes()
+            #endif BRIDGING_HEADER_H
+            "#
+            .as_bytes(),
         ),
         Err(_) => Ok(()),
     };
@@ -34,16 +35,14 @@ fn main() {
 
     // 2. Compile Swift library
     let mut cmd = Command::new("swiftc");
-    
+
     cmd.arg("-emit-library")
         .arg("-static")
-
         .arg("-module-name")
         .arg("swift_colors")
 
         .arg("-import-objc-header")
         .arg("./swift_bridge/bridging-header.h")
-
         .arg("./src/macos/colors.swift")
         .arg("./swift_bridge/egui_system_theme/egui_system_theme.swift")
         .arg("./swift_bridge/SwiftBridgeCore.swift");
@@ -61,9 +60,9 @@ fn main() {
     if !exit_status.status.success() {
         panic!(
             r#"
-Stderr: {}
-Stdout: {}
-"#,
+            Stderr: {}
+            Stdout: {}
+            "#,
             String::from_utf8(exit_status.stderr).unwrap(),
             String::from_utf8(exit_status.stdout).unwrap(),
         )

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,71 @@
+#[cfg(not(all(feature = "dynamic-mac-colors", target_os = "macos")))]
+fn main() {
+    return;
+}
+
+#[cfg(all(feature = "dynamic-mac-colors", target_os = "macos"))]
+fn main() {
+    use std::process::Command;
+    use std::io::Write;
+
+    let _ = std::fs::create_dir("./swift_bridge");
+    let bridging_header = std::fs::File::create("./swift_bridge/bridging-header.h");
+
+    let _ = match bridging_header {
+        Ok(mut f) => f.write_all(
+        r#"
+        #ifndef BRIDGING_HEADER_H
+        #define BRIDGING_HEADER_H
+
+        #import "./SwiftBridgeCore.h"
+        #import "./egui_system_theme/egui_system_theme.h"
+
+        #endif BRIDGING_HEADER_H
+        "#.as_bytes()
+        ),
+        Err(_) => Ok(()),
+    };
+
+    // 1. Use `swift-bridge-build` to generate Swift/C FFI glue.
+    //    You can also use the `swift-bridge` CLI.
+    let bridge_files = vec!["src/macos/dynamic.rs"];
+    swift_bridge_build::parse_bridges(bridge_files)
+        .write_all_concatenated("./swift_bridge", "egui_system_theme");
+
+    // 2. Compile Swift library
+    let mut cmd = Command::new("swiftc");
+    
+    cmd.arg("-emit-library")
+        .arg("-static")
+
+        .arg("-module-name")
+        .arg("swift_colors")
+
+        .arg("-import-objc-header")
+        .arg("./swift_bridge/bridging-header.h")
+
+        .arg("./src/macos/colors.swift")
+        .arg("./swift_bridge/egui_system_theme/egui_system_theme.swift")
+        .arg("./swift_bridge/SwiftBridgeCore.swift");
+
+    if std::env::var("PROFILE").unwrap() == "release" {
+        cmd.args(&["-c", "release"]);
+    }
+
+    // 3. Link to Swift library
+    println!("cargo:rustc-link-lib=static=swift_colors");
+    println!("cargo:rustc-link-search=./");
+
+    let exit_status = cmd.spawn().unwrap().wait_with_output().unwrap();
+
+    if !exit_status.status.success() {
+        panic!(
+            r#"
+Stderr: {}
+Stdout: {}
+"#,
+            String::from_utf8(exit_status.stderr).unwrap(),
+            String::from_utf8(exit_status.stdout).unwrap(),
+        )
+    }
+}

--- a/build.rs
+++ b/build.rs
@@ -1,7 +1,5 @@
 #[cfg(not(all(feature = "dynamic-mac-colors", target_os = "macos")))]
-fn main() {
-    return;
-}
+fn main() {}
 
 #[cfg(all(feature = "dynamic-mac-colors", target_os = "macos"))]
 fn main() {
@@ -48,7 +46,7 @@ fn main() {
         .arg("./swift_bridge/SwiftBridgeCore.swift");
 
     if std::env::var("PROFILE").unwrap() == "release" {
-        cmd.args(&["-c", "release"]);
+        cmd.args(["-c", "release"]);
     }
 
     // 3. Link to Swift library
@@ -57,14 +55,12 @@ fn main() {
 
     let exit_status = cmd.spawn().unwrap().wait_with_output().unwrap();
 
-    if !exit_status.status.success() {
-        panic!(
-            r#"
-            Stderr: {}
-            Stdout: {}
-            "#,
-            String::from_utf8(exit_status.stderr).unwrap(),
-            String::from_utf8(exit_status.stdout).unwrap(),
-        )
-    }
+    assert!(exit_status.status.success(), 
+        r#"
+        Stderr: {}
+        Stdout: {}
+        "#,
+        String::from_utf8(exit_status.stderr).unwrap(),
+        String::from_utf8(exit_status.stdout).unwrap(),
+    );
 }

--- a/examples/demo_app.rs
+++ b/examples/demo_app.rs
@@ -37,13 +37,24 @@ impl SystemThemeDemoApp {
 impl App for SystemThemeDemoApp {
     fn update(&mut self, ctx: &Context, _frame: &mut eframe::Frame) {
         egui_system_theme::titlebar_extension(ctx, "menu_bar_real", true, |ui| {
-            ui.menu_button("File", |ui| {
-                if ui.button("New").clicked()
-                    || ui.button("Open").clicked()
-                    || ui.button(":)").clicked()
-                {
-                    ui.close_menu();
-                }
+            ui.horizontal(|ui| {
+                ui.menu_button("File", |ui| {
+                    if ui.button("New").clicked()
+                        || ui.button("Open").clicked()
+                        || ui.button(":)").clicked()
+                    {
+                        ui.close_menu();
+                    };
+                });
+
+                ui.menu_button("Set Style", |ui| {
+                    if ui.button("Default").clicked() {
+                        ctx.set_style(Style::default());
+                    }
+                    if ui.button("System").clicked() {
+                        ctx.set_style(egui_system_theme::system_theme().unwrap());
+                    }
+                });
             });
         });
 

--- a/readme.md
+++ b/readme.md
@@ -13,5 +13,7 @@ Uses [GetSysColor](https://learn.microsoft.com/en-us/windows/win32/api/winuser/n
 NOTE: Some modern versions of Windows don't update this with the user's dark mode/accent color preferences for some reason, so if you are targeting windows, you should probably have an option to use the default `egui` theme.
 
 ### MacOS
-Not supported yet, as i don't have access to any systems running it.
-If you do, and want to help, a pull request would be greatly appreciated!
+Uses ojbc to get the system accent color.
+
+Only accent colors supported, as MacOS does not give the color values of colors.
+You could hard code the values if you can figreout which one is which.

--- a/readme.md
+++ b/readme.md
@@ -5,7 +5,7 @@ This crate reads the current system theme and gives you an `egui` style to use i
 If the user is using KDE Plasma, it will read $HOME/.config/kdeglobals.
 
 Otherwise, it will try to read the GTK4 or GTK3 theme via $HOME/.config/gtk-X.0/settings.ini.
-This is more limited, as i had to partially write a css interpreter to get it working, if your theme doesn't work, make an issue!
+This is more limited, as I had to partially write a css interpreter to get it working, if your theme doesn't work, make an issue!
 
 ### Windows
 Uses [GetSysColor](https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-getsyscolor).
@@ -13,7 +13,5 @@ Uses [GetSysColor](https://learn.microsoft.com/en-us/windows/win32/api/winuser/n
 NOTE: Some modern versions of Windows don't update this with the user's dark mode/accent color preferences for some reason, so if you are targeting windows, you should probably have an option to use the default `egui` theme.
 
 ### MacOS
-Uses ojbc to get the system accent color.
-
-Only accent colors supported, as MacOS does not give the color values of colors.
-You could hard code the values if you can figreout which one is which.
+Uses ojbc to get the system accent color and the others are hard coded.\
+With the dynamic-mac-colors feature swift is used to get the ui colors this should suport high contrast mode.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,12 +42,11 @@ pub fn system_theme() -> Result<Style, Box<dyn Error>> {
 pub fn titlebar_extension<R>(ctx: &Context, id: impl Into<Id>, menubar_style: bool, add_contents: impl FnOnce(&mut Ui) -> R) -> InnerResponse<R> {
     let id = id.into();
     
-    TopBottomPanel::top(id)
-        .frame(
-            Frame::side_top_panel(&ctx.style())
-                .fill(ctx.style().visuals.titlebar(ctx.input(|i| i.focused)))
-                .inner_margin(Margin::same(0.))
-        )
+    TopBottomPanel::top(id).frame(
+        Frame::side_top_panel(&ctx.style())
+            .fill(ctx.style().visuals.titlebar(ctx.input(|i| i.focused)))
+            .inner_margin(Margin::same(0.))
+    )
         .show(ctx, |ui| {
             let title_bar_response =
                 ui.interact(ui.max_rect(), id.with("interaction"), Sense::click_and_drag());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,11 +23,13 @@ use linux as platform;
 pub(crate) static DARK_LIGHT_MODE: Lazy<dark_light::Mode> = Lazy::new(dark_light::detect);
 
 pub fn system_theme() -> Result<Style, Box<dyn Error>> {
-    let mut style = Style::default();
-    style.visuals = match *DARK_LIGHT_MODE {
-        dark_light::Mode::Default => Visuals::default(),
-        dark_light::Mode::Dark => Visuals::dark(),
-        dark_light::Mode::Light => Visuals::light(),
+    let mut style = Style {
+        visuals: match *DARK_LIGHT_MODE {
+            dark_light::Mode::Default => Visuals::default(),
+            dark_light::Mode::Dark => Visuals::dark(),
+            dark_light::Mode::Light => Visuals::light(),
+        }, 
+        ..Style::default()
     };
 
     platform::style(&mut style)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,7 @@ pub fn system_theme() -> Result<Style, Box<dyn Error>> {
             dark_light::Mode::Default => Visuals::default(),
             dark_light::Mode::Dark => Visuals::dark(),
             dark_light::Mode::Light => Visuals::light(),
-        }, 
+        },
         ..Style::default()
     };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,6 +104,7 @@ impl VisualsExt for Visuals {
 pub(crate) trait Color32Ext {
     fn mutate(self, towards: Rgba, amount: f32) -> Self;
 }
+
 impl Color32Ext for Color32 {
     fn mutate(self, towards: Rgba, amount: f32) -> Self {
         lerp(Rgba::from(self)..=towards, amount).into()

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -1,5 +1,94 @@
+#![cfg(target_os = "macos")]
+
 use crate::*;
+use cocoa::{base::{id, nil}, foundation::NSString};
+use objc::{msg_send, class, sel, sel_impl};
 
 pub fn style(style: &mut Style) -> Result<(), Box<dyn Error>> {
-    // TODO Currently macos is not supported
+    // TODO Currently only accent color is supported
+
+    // text works better with the accent colors when it's more like the macos text color
+    if dark_light::detect() == dark_light::Mode::Dark {
+        style.visuals.override_text_color = Some(style.visuals.text_color().mutate(Rgba::WHITE, 0.7));
+    }
+
+    // if the accent color is Multicolor then it will not be set
+    let highlight = match get_ns_accent_color() {
+        Some(c) => c.into(),
+        None => return Ok(()),
+    };
+
+    style.visuals.widgets.hovered.bg_stroke = Stroke::new(1., highlight);
+    style.visuals.widgets.active.bg_fill = highlight;
+    style.visuals.widgets.active.weak_bg_fill = highlight;
+    style.visuals.widgets.active.bg_stroke = Stroke::new(1., highlight);
+    style.visuals.widgets.open.bg_fill = highlight;
+    style.visuals.widgets.open.bg_stroke = Stroke::new(1., highlight);
+    style.visuals.hyperlink_color = highlight;
+    style.visuals.selection.bg_fill = highlight;
+
+    Ok(())
+}
+
+// the AccentColor code is from [dan-lee/tao](https://github.com/dan-lee/tao/tree/feat/accent_color_macos)
+
+/// The different macos accent colors
+#[non_exhaustive]
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub enum AccentColor {
+    Graphite,
+    Red,
+    Orange,
+    // ilegible
+    Yellow,
+    Green,
+    Blue,
+    Purple,
+    Pink,
+}
+
+/// Convert an `AccentColor` to a `Color32` use numbers from the settings samples in macos
+impl From<AccentColor> for Color32 {
+    fn from(color: AccentColor) -> Self {
+        // colors from the settings samples
+        match color {
+            AccentColor::Graphite => Color32::from_rgb(140, 140, 140),
+            AccentColor::Red => Color32::from_rgb(236, 95, 93),
+            AccentColor::Orange => Color32::from_rgb(232, 136, 58),
+            AccentColor::Yellow => Color32::from_rgb(246, 200, 68),
+            AccentColor::Green => Color32::from_rgb(120, 184, 86),
+            AccentColor::Blue => Color32::from_rgb(52, 120, 246),
+            AccentColor::Purple => Color32::from_rgb(155, 85, 163),
+            AccentColor::Pink => Color32::from_rgb(228, 92, 156),
+        }
+    }
+}
+
+/// Get the system accent color using ojbc
+fn get_ns_accent_color() -> Option<AccentColor> {
+    let color_int: id;
+    unsafe {
+        let key_name = NSString::alloc(nil).init_str("AppleAccentColor");
+
+        let user_defaults: id = msg_send![class!(NSUserDefaults), standardUserDefaults];
+        let color_obj: id = msg_send![user_defaults, objectForKey: key_name];
+
+        if color_obj == nil {
+            return None;
+        }
+
+        color_int = msg_send![user_defaults, integerForKey: key_name];
+    }
+
+    match color_int as i8 {
+        -1 => Some(AccentColor::Graphite),
+        0 => Some(AccentColor::Red),
+        1 => Some(AccentColor::Orange),
+        2 => Some(AccentColor::Yellow),
+        3 => Some(AccentColor::Green),
+        4 => Some(AccentColor::Blue),
+        5 => Some(AccentColor::Purple),
+        6 => Some(AccentColor::Pink),
+        _ => None,
+    }
 }

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -41,6 +41,51 @@ pub fn style(style: &mut Style) -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
+/// Takes the `Color32` consts and converts them to the MacOS specified versions.\
+/// The color will be unchanged if it's not one of the consts.\
+/// https://developer.apple.com/design/human-interface-guidelines/color#Specifications
+pub fn color32_to_macos_color(color: Color32) -> Color32 {
+    if *DARK_LIGHT_MODE == dark_light::Mode::Dark {
+        match color {
+            Color32::BLUE => Color32::from_rgb(10, 132, 255),
+            Color32::BROWN => Color32::from_rgb(172, 142, 104),
+            Color32::GRAY => Color32::from_rgb(152, 152, 157),
+            Color32::GREEN => Color32::from_rgb(50, 215, 75),
+            Color32::ORANGE => Color32::from_rgb(255, 159, 10),
+            Color32::RED => Color32::from_rgb(255, 69, 58),
+            Color32::YELLOW => Color32::from_rgb(255, 214, 10),
+            _ => match_dark_light_colors(color)
+        }
+    } else {
+        match color {
+            Color32::BLUE => Color32::from_rgb(0, 122, 255),
+            Color32::BROWN => Color32::from_rgb(162, 132, 94),
+            Color32::GRAY => Color32::from_rgb(142, 142, 147),
+            Color32::GREEN => Color32::from_rgb(40, 205, 65),
+            Color32::ORANGE => Color32::from_rgb(255, 149, 0),
+            Color32::RED => Color32::from_rgb(255, 59, 48),
+            Color32::YELLOW => Color32::from_rgb(255, 204, 0),
+            _ => match_dark_light_colors(color)
+        }
+    }
+}
+
+/// dark colors are the light mode accessible colors, light colors are the inverse.\
+/// The color will be unchanged if it's not one of the consts.
+const fn match_dark_light_colors(color: Color32) -> Color32 {
+    match color {
+        Color32::DARK_BLUE => Color32::from_rgb(0, 64, 221),
+        Color32::DARK_GRAY => Color32::from_rgb(105, 105, 110),
+        Color32::DARK_GREEN => Color32::from_rgb(0, 125, 27),
+        Color32::DARK_RED => Color32::from_rgb(215, 0, 21),
+        Color32::LIGHT_BLUE => Color32::from_rgb(90, 200, 245), // Cyan
+        Color32::LIGHT_GRAY => Color32::from_rgb(152, 152, 157),
+        Color32::LIGHT_RED => Color32::from_rgb(255, 105, 97),
+        Color32::LIGHT_YELLOW => Color32::from_rgb(255, 212, 38),
+        _ => color
+    }
+}
+
 // the AccentColor code is from [dan-lee/tao](https://github.com/dan-lee/tao/tree/feat/accent_color_macos)
 
 /// The different macos accent colors

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -1,5 +1,3 @@
-#![cfg(target_os = "macos")]
-
 use crate::*;
 use cocoa::{base::{id, nil}, foundation::NSString};
 use objc::{msg_send, class, sel, sel_impl};
@@ -8,7 +6,7 @@ pub fn style(style: &mut Style) -> Result<(), Box<dyn Error>> {
     // TODO Currently only accent color is supported
 
     // text works better with the accent colors when it's more like the macos text color
-    if dark_light::detect() == dark_light::Mode::Dark {
+    if *DARK_LIGHT_MODE == dark_light::Mode::Dark {
         style.visuals.override_text_color = Some(style.visuals.text_color().mutate(Rgba::WHITE, 0.7));
     }
 

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -8,22 +8,35 @@ pub fn style(style: &mut Style) -> Result<(), Box<dyn Error>> {
     // text works better with the accent colors when it's more like the macos text color
     if *DARK_LIGHT_MODE == dark_light::Mode::Dark {
         style.visuals.override_text_color = Some(style.visuals.text_color().mutate(Rgba::WHITE, 0.7));
+
+        let fill = Color32::from_rgb(42, 42, 42); // background color of dark mode appkit apps
+        style.visuals.panel_fill = fill;
+        style.visuals.window_fill = fill;
+        // widget_text is also used for window borders according to the documentation
+        style.visuals.window_stroke = Stroke::new(1., fill);
+
+        style.visuals.widgets.noninteractive.bg_fill = fill.mutate(Rgba::BLACK, 0.1);
+        style.visuals.widgets.noninteractive.weak_bg_fill = fill; // Used for text input hints and selected windows
+        style.visuals.widgets.inactive.bg_fill = fill;
+        style.visuals.widgets.inactive.weak_bg_fill = fill;
+        style.visuals.widgets.inactive.fg_stroke = Stroke::new(1., Color32::GRAY.mutate(Rgba::WHITE, 0.1));
+        style.visuals.widgets.inactive.bg_stroke = Stroke::new(1., Color32::from_rgb(87, 87, 87));
+        style.visuals.extreme_bg_color = Color32::from_rgb(54, 54, 54);
     }
 
-    // if the accent color is Multicolor then it will not be set
-    let highlight = match get_ns_accent_color() {
-        Some(c) => c.into(),
-        None => return Ok(()),
-    };
+    // if the accent color is Multicolor then it will be set to blue as MacOS does
+    let highlight: Color32 = get_ns_accent_color().unwrap_or(AccentColor::Blue).into();
+    // improve legibliety
+    let highlight_fill = highlight.mutate(Rgba::BLACK, 0.1);
 
     style.visuals.widgets.hovered.bg_stroke = Stroke::new(1., highlight);
     style.visuals.widgets.active.bg_fill = highlight;
-    style.visuals.widgets.active.weak_bg_fill = highlight;
+    style.visuals.widgets.active.weak_bg_fill = highlight_fill;
     style.visuals.widgets.active.bg_stroke = Stroke::new(1., highlight);
-    style.visuals.widgets.open.bg_fill = highlight;
+    style.visuals.widgets.open.bg_fill = highlight_fill;
     style.visuals.widgets.open.bg_stroke = Stroke::new(1., highlight);
-    style.visuals.hyperlink_color = highlight;
-    style.visuals.selection.bg_fill = highlight;
+    style.visuals.hyperlink_color = highlight_fill;
+    style.visuals.selection.bg_fill = highlight_fill;
 
     Ok(())
 }

--- a/src/macos/colors.swift
+++ b/src/macos/colors.swift
@@ -59,6 +59,8 @@ func colors(color: Colors) -> (Double, Double, Double, Double) {
         NSColor.knobColor.cgColor.components!
     case Colors.Stripe:
         NSColor.alternatingContentBackgroundColors[0].cgColor.components!
+    case Colors.ScrollBar:
+        NSColor.scrollBarColor.cgColor.components!
     }
     
     return (color[0], color[1], color[2], color[3])

--- a/src/macos/colors.swift
+++ b/src/macos/colors.swift
@@ -1,0 +1,65 @@
+import SwiftUI
+import AppKit
+
+func colors(color: Colors) -> (Double, Double, Double, Double) {
+    let color: [CGFloat] = switch color {
+    case Colors.Text:
+        NSColor.textColor.cgColor.components!
+    case Colors.Link:
+        NSColor.linkColor.cgColor.components!
+    case Colors.Black:
+        NSColor(Color.black).cgColor.components!
+    case Colors.Red:
+        NSColor.systemRed.cgColor.components!
+    case Colors.White:
+        NSColor(Color.white).cgColor.components!
+    case Colors.Clear:
+        NSColor(Color.clear).cgColor.components!
+    case Colors.Blue:
+        NSColor.systemBlue.cgColor.components!
+    case Colors.Gray:
+        NSColor.systemGray.cgColor.components!
+    case Colors.Green:
+        NSColor.systemGreen.cgColor.components!
+    case Colors.Primary:
+        NSColor(Color.primary).cgColor.components!
+    case Colors.Accent:
+        NSColor(Color.accentColor).cgColor.components!
+    case Colors.Secondary:
+        NSColor(Color.secondary).cgColor.components!
+    case Colors.Yellow:
+        NSColor.systemYellow.cgColor.components!
+    case Colors.Brown:
+        NSColor.systemBrown.cgColor.components!
+    case Colors.Cyan:
+        NSColor.systemCyan.cgColor.components!
+    case Colors.Indigo:
+        NSColor.systemIndigo.cgColor.components!
+    case Colors.Mint:
+        NSColor.systemMint.cgColor.components!
+    case Colors.Orange:
+        NSColor.systemOrange.cgColor.components!
+    case Colors.Pink:
+        NSColor.systemPink.cgColor.components!
+    case Colors.Purple:
+        NSColor.systemPurple.cgColor.components!
+    case Colors.Teal:
+        NSColor.systemTeal.cgColor.components!
+    case Colors.Separator:
+        NSColor.separatorColor.cgColor.components!
+    case Colors.TextEdit:
+        NSColor.textBackgroundColor.cgColor.components!
+    case Colors.Shadow:
+        NSColor.shadowColor.cgColor.components!
+    case Colors.InputCursor:
+        NSColor.textInsertionPointColor.cgColor.components!
+    case Colors.Window:
+        NSColor.windowBackgroundColor.cgColor.components!
+    case Colors.InactiveFg:
+        NSColor.knobColor.cgColor.components!
+    case Colors.Stripe:
+        NSColor.alternatingContentBackgroundColors[0].cgColor.components!
+    }
+    
+    return (color[0], color[1], color[2], color[3])
+}

--- a/src/macos/dynamic.rs
+++ b/src/macos/dynamic.rs
@@ -1,12 +1,12 @@
 #![cfg(all(feature = "dynamic-mac-colors", target_os = "macos"))]
 
 use crate::*;
-pub use ffi::{Colors, colors};
+pub(crate) use ffi::{colors, Colors};
 
 #[swift_bridge::bridge]
 mod ffi {
     // The difarent things you can request the color of
-    pub enum Colors {
+    pub(crate) enum Colors {
         Text,
         Link,
         Black,
@@ -45,7 +45,11 @@ mod ffi {
 fn swift_to_color32(colors: (f64, f64, f64, f64)) -> Color32 {
     // maitily the 0-1 to make it 0-255
     // 0.? * 255.999 as u8
-    Color32::from_rgb((colors.0 * 255.999) as u8, (colors.1 * 255.999) as u8, (colors.2 * 255.999) as u8)    
+    Color32::from_rgb(
+        (colors.0 * 255.999) as u8,
+        (colors.1 * 255.999) as u8,
+        (colors.2 * 255.999) as u8,
+    )
 }
 
 /// get the ui color from swift
@@ -97,4 +101,18 @@ pub(crate) fn style(style: &mut Style) -> Result<(), Box<dyn Error>> {
     style.visuals.widgets.hovered.bg_fill = highlight_fill;
 
     Ok(())
+}
+
+pub(crate) fn color32_to_macos_color(color: Color32) -> Color32 {
+    match color {
+        Color32::BLUE => get_color!(Colors::Blue),
+        Color32::BROWN => get_color!(Colors::Brown),
+        Color32::GRAY => get_color!(Colors::Gray),
+        Color32::GREEN => get_color!(Colors::Green),
+        Color32::ORANGE => get_color!(Colors::Orange),
+        Color32::RED => get_color!(Colors::Red),
+        Color32::YELLOW => get_color!(Colors::Yellow),
+        Color32::TRANSPARENT => get_color!(Colors::Clear),
+        _ => macos::match_dark_light_colors(color),
+    }
 }

--- a/src/macos/dynamic.rs
+++ b/src/macos/dynamic.rs
@@ -35,10 +35,11 @@ mod ffi {
         Window,
         InactiveFg,
         Stripe,
+        ScrollBar,
     }
 
     extern "Swift" {
-        pub fn colors(color: Colors) -> (f64, f64, f64, f64);
+        pub(crate) fn colors(color: Colors) -> (f64, f64, f64, f64);
     }
 }
 
@@ -61,11 +62,11 @@ macro_rules! get_color {
 
 pub(crate) fn style(style: &mut Style) -> Result<(), Box<dyn Error>> {
     style.visuals.override_text_color = Some(get_color!(Colors::Text));
-    style.visuals.hyperlink_color = get_color!(Colors::Link);
+    style.visuals.hyperlink_color = get_color!(Colors::Link).mutate(get_color!(Colors::Accent).into(), 0.2);
 
     style.visuals.widgets.hovered.expansion = 0.0;
     style.visuals.widgets.inactive.fg_stroke = Stroke::new(1., get_color!(Colors::InactiveFg));
-    style.visuals.extreme_bg_color = get_color!(Colors::TextEdit);
+    style.visuals.extreme_bg_color = get_color!(Colors::TextEdit).mutate(Rgba::WHITE, 0.01);
     style.visuals.faint_bg_color = get_color!(Colors::Stripe).mutate(Rgba::WHITE, 0.05);
     style.visuals.widgets.inactive.fg_stroke = Stroke::new(1., Color32::WHITE.mutate(get_color!(Colors::Accent).into(), 0.1));
 

--- a/src/macos/dynamic.rs
+++ b/src/macos/dynamic.rs
@@ -1,0 +1,100 @@
+#![cfg(all(feature = "dynamic-mac-colors", target_os = "macos"))]
+
+use crate::*;
+pub use ffi::{Colors, colors};
+
+#[swift_bridge::bridge]
+mod ffi {
+    // The difarent things you can request the color of
+    pub enum Colors {
+        Text,
+        Link,
+        Black,
+        Red,
+        White,
+        Clear,
+        Blue,
+        Gray,
+        Green,
+        Primary,
+        Accent,
+        Secondary,
+        Yellow,
+        Brown,
+        Cyan,
+        Indigo,
+        Mint,
+        Orange,
+        Pink,
+        Purple,
+        Teal,
+        Separator,
+        TextEdit,
+        Shadow,
+        InputCursor,
+        Window,
+        InactiveFg,
+        Stripe,
+    }
+
+    extern "Swift" {
+        pub fn colors(color: Colors) -> (f64, f64, f64, f64);
+    }
+}
+
+fn swift_to_color32(colors: (f64, f64, f64, f64)) -> Color32 {
+    // maitily the 0-1 to make it 0-255
+    // 0.? * 255.999 as u8
+    Color32::from_rgb((colors.0 * 255.999) as u8, (colors.1 * 255.999) as u8, (colors.2 * 255.999) as u8)    
+}
+
+/// get the ui color from swift
+macro_rules! get_color {
+    ($item:expr) => {
+        swift_to_color32(colors($item))
+    };
+}
+
+pub(crate) fn style(style: &mut Style) -> Result<(), Box<dyn Error>> {
+    style.visuals.override_text_color = Some(get_color!(Colors::Text));
+    style.visuals.hyperlink_color = get_color!(Colors::Link);
+
+    style.visuals.widgets.hovered.expansion = 0.0;
+    style.visuals.widgets.inactive.fg_stroke = Stroke::new(1., get_color!(Colors::InactiveFg));
+    style.visuals.extreme_bg_color = get_color!(Colors::TextEdit);
+    style.visuals.faint_bg_color = get_color!(Colors::Stripe).mutate(Rgba::WHITE, 0.05);
+    style.visuals.widgets.inactive.fg_stroke = Stroke::new(1., Color32::WHITE.mutate(get_color!(Colors::Accent).into(), 0.1));
+
+    if *DARK_LIGHT_MODE == dark_light::Mode::Dark {
+        // check box
+        style.visuals.widgets.inactive.bg_fill = Color32::from_rgb(95, 95, 95);
+        style.visuals.widgets.active.bg_fill =  Color32::from_rgb(95, 95, 95).mutate(get_color!(Colors::Accent).into(), 0.2);
+        style.visuals.widgets.inactive.bg_stroke = Stroke::new(0.34, Color32::from_rgb(120, 120, 120));
+    } else {
+        style.visuals.widgets.inactive.bg_fill = Color32::from_rgb(214, 214, 214);
+        style.visuals.widgets.inactive.bg_fill = Color32::from_rgb(214, 214, 214).mutate(get_color!(Colors::Accent).into(), 0.2);
+    }
+
+    style.visuals.text_cursor.stroke.color = get_color!(Colors::InputCursor);
+
+    let fill = get_color!(Colors::Window);
+    style.visuals.panel_fill = fill;
+    style.visuals.window_fill = fill;
+    style.visuals.widgets.noninteractive.bg_stroke = Stroke::new(0.45, get_color!(Colors::Separator));
+
+    let highlight: Color32 = get_color!(Colors::Accent);
+    // improve legibliety
+    let highlight_fill = highlight.mutate(Rgba::BLACK, 0.1);
+
+    style.visuals.widgets.hovered.bg_stroke = Stroke::new(1., highlight);
+    style.visuals.widgets.active.bg_fill = highlight;
+    style.visuals.widgets.active.weak_bg_fill = highlight_fill;
+    style.visuals.widgets.active.bg_stroke = Stroke::new(1., highlight);
+    style.visuals.widgets.open.bg_fill = highlight_fill;
+    style.visuals.widgets.open.bg_stroke = Stroke::new(1., highlight);
+    style.visuals.hyperlink_color = highlight_fill;
+    style.visuals.selection.bg_fill = highlight_fill;
+    style.visuals.widgets.hovered.bg_fill = highlight_fill;
+
+    Ok(())
+}

--- a/src/macos/mod.rs
+++ b/src/macos/mod.rs
@@ -1,7 +1,7 @@
 use crate::*;
-use cocoa::{base::{id, nil}, foundation::NSString};
-use objc::{msg_send, class, sel, sel_impl};
-#[cfg(all(feature = "dynamic-mac-colors", target_os = "macos"))]
+use cocoa::{base::{id, nil}, foundation::NSString,};
+use objc::{class, msg_send, sel, sel_impl};
+// #[cfg(all(feature = "dynamic-mac-colors", target_os = "macos"))]
 mod dynamic;
 
 pub fn style(style: &mut Style) -> Result<(), Box<dyn Error>> {
@@ -66,7 +66,15 @@ fn set_accent(style: &mut Style) {
 /// Takes the `Color32` consts and converts them to the MacOS specified versions.\
 /// The color will be unchanged if it's not one of the consts.\
 /// https://developer.apple.com/design/human-interface-guidelines/color#Specifications
-pub fn color32_to_macos_color(color: Color32) -> Color32 {
+pub fn get_macos_color(color: Color32) -> Color32 {
+    #[cfg(all(feature = "dynamic-mac-colors", target_os = "macos"))]
+    return dynamic::color32_to_macos_color(color);
+
+    #[cfg(not(feature = "dynamic-mac-colors"))]
+    static_macos_color(color)
+}
+
+fn static_macos_color(color: Color32) -> Color32 {
     if *DARK_LIGHT_MODE == dark_light::Mode::Dark {
         match color {
             Color32::BLUE => Color32::from_rgb(10, 132, 255),
@@ -76,7 +84,7 @@ pub fn color32_to_macos_color(color: Color32) -> Color32 {
             Color32::ORANGE => Color32::from_rgb(255, 159, 10),
             Color32::RED => Color32::from_rgb(255, 69, 58),
             Color32::YELLOW => Color32::from_rgb(255, 214, 10),
-            _ => match_dark_light_colors(color)
+            _ => match_dark_light_colors(color),
         }
     } else {
         match color {
@@ -87,14 +95,14 @@ pub fn color32_to_macos_color(color: Color32) -> Color32 {
             Color32::ORANGE => Color32::from_rgb(255, 149, 0),
             Color32::RED => Color32::from_rgb(255, 59, 48),
             Color32::YELLOW => Color32::from_rgb(255, 204, 0),
-            _ => match_dark_light_colors(color)
+            _ => match_dark_light_colors(color),
         }
     }
 }
 
 /// dark colors are the light mode accessible colors, light colors are the inverse.\
 /// The color will be unchanged if it's not one of the consts.
-const fn match_dark_light_colors(color: Color32) -> Color32 {
+pub(crate) const fn match_dark_light_colors(color: Color32) -> Color32 {
     match color {
         Color32::DARK_BLUE => Color32::from_rgb(0, 64, 221),
         Color32::DARK_GRAY => Color32::from_rgb(105, 105, 110),
@@ -104,7 +112,7 @@ const fn match_dark_light_colors(color: Color32) -> Color32 {
         Color32::LIGHT_GRAY => Color32::from_rgb(152, 152, 157),
         Color32::LIGHT_RED => Color32::from_rgb(255, 105, 97),
         Color32::LIGHT_YELLOW => Color32::from_rgb(255, 212, 38),
-        _ => color
+        _ => color,
     }
 }
 
@@ -117,7 +125,6 @@ pub enum AccentColor {
     Graphite,
     Red,
     Orange,
-    // ilegible
     Yellow,
     Green,
     Blue,


### PR DESCRIPTION
This PR adds support for all of the **accent color** options on **MacOS** with as little unsafe code as possible.
It uses cocoa and objc to do this.

It also adds full color support with the `dynamic-mac-colors` feature.
This links to swift code that relays on the Mac SDK so for cross compelling support it is off by default.

It has been **tested** with **all** the colors.
It also adds a util function for getting the MacOS specified versions of the `Color32` consts.